### PR TITLE
Nav bar paths now reference path names as opposed to hard coded URLs

### DIFF
--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -12,8 +12,7 @@ class PlayersController < ApplicationController
   def pick
     @picks = Player.find(params[:player_store])
     @pick_id = @picks.id
-    @team_id = current_team.id
-    @insert = Roster.create(player_id: @pick_id, team_id: @team_id)
+    @insert = Roster.create(player_id: @pick_id, team_id: session[:team])
     @insert.save
     @pickname = @picks.name
   end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,19 +21,19 @@
       %nav
         %ul#myTopnav.topnav
           %li
-            = link_to 'Create New Team', '/' 
+            = link_to 'Create New Team', root_path 
           %li 
-            = link_to 'All Teams', '/rosters'
+            = link_to 'All Teams', rosters_path
           %li
-            = link_to 'Draft Now', '/players'
+            = link_to 'Draft Now', players_path
           %li 
-            = link_to 'Edit Team Info', '/teams/:id/edit' 
+            = link_to 'Edit Team Info', edit_team_path(id: session[:team]) 
           - if current_user
             %li.usr
               Welcome,
               = current_user.name.titleize
             %li  
-              = link_to 'Logout', '/logout', method: :delete
+              = link_to 'Logout', logout_path, method: :delete
             %li
               = link_to 'Change Team', teams_path
           - else


### PR DESCRIPTION
Hey Tian, the team session is now hard coded and that now sets the "edit team" path as well as controls the draft information passed in the draft function. Is it possible in the Change Team page to highlight whichever team is selected? Right now I'm just printing out the ID of the team selected so that I know which one I've got selected, but I think it would be better if the tile for the team that is selected graphically represents that in some way. Either way - I think we're done for now. At the very least we've gone pretty far beyond Karl's expectations for this assignment, so awesome job.
